### PR TITLE
Fixed bug where if ACS doesn't return the classname for a newly created ...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,8 +147,8 @@ exports.create = function create(APIBuilder, server) {
 			 * @param {object} values - An object of values to initialize the instance with.
 			 * @returns {Instance} A new instance of the specified model.
 			 */
-			function createInstance(model, values) {
-				var instance = model.instance(values, true);
+			function createInstance(model, values, params) {
+				var instance = model.instance(values, true, params);
 				instance.setPrimaryKey(values.id);
 				model._instanceMethods && Object.keys(model._instanceMethods).forEach(function (method) {
 					instance[method] = model._instanceMethods[method].bind(instance);
@@ -285,7 +285,7 @@ exports.create = function create(APIBuilder, server) {
 
 						if (Array.isArray(response) && (!methodInfo.response || !methodInfo.response.singleElement)) {
 							return callback(null, new APIBuilder.Collection(responseModel, response.map(function (item) {
-								return createInstance(responseModel, item);
+								return createInstance(responseModel, item, params);
 							}, this)));
 						}
 
@@ -310,7 +310,7 @@ exports.create = function create(APIBuilder, server) {
 							return callback(null, instance);
 						}
 
-						callback(null, createInstance(responseModel, response));
+						callback(null, createInstance(responseModel, response, params));
 					}.bind(this));
 				};
 			}, this);

--- a/models/custom_object.js
+++ b/models/custom_object.js
@@ -46,7 +46,7 @@ module.exports = APIBuilder.Model.extend('customObject', {
 		}
 	},
 
-	instance: function instance(values, skipNotFound) {
+	instance: function instance(values, skipNotFound, params) {
 		if (values.cname) {
 			values.classname = values.cname;
 			delete values.cname;
@@ -59,6 +59,8 @@ module.exports = APIBuilder.Model.extend('customObject', {
 				delete values[key];
 			}
 		}, this);
+
+		values.classname || (values.classname = params.classname);
 
 		return new APIBuilder.Instance(this, values, skipNotFound);
 	},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "appc.acs",
 	"description": "ACS Connector",
-	"version": "1.0.14",
+	"version": "1.0.15",
 	"author": "Jeff Haynie",
 	"license": "",
 	"framework": "none",

--- a/test/test-custom-object.js
+++ b/test/test-custom-object.js
@@ -120,7 +120,6 @@ describe('Custom Objects', function () {
 				should(customObj.fields.color).equal(params.color);
 
 				testCustomObj = customObj;
-
 				done();
 			});
 		});


### PR DESCRIPTION
...custom object, the classname is injected into the values before creating the instance.
