### PR TITLE
Allowed payload-too-large errors to return from update requests

### DIFF
--- a/lib/schema/wireModel.js
+++ b/lib/schema/wireModel.js
@@ -234,7 +234,8 @@ exports.wireModel = function (acsObj, model, name, isCustomObject) {
 
 			db[methodInfo.apiMethodName].call(db, params, function (err, results) {
 				if (err) {
-					if (err.errorCode === 1004 && destMethod !== '_create') {
+					// allow error to propogate for create/update because 1004 can be a payload-too-large error
+					if (err.errorCode === 1004 && destMethod !== '_create' && destMethod !== '_update') {
 						// invalid object id is this error code. for example passing an
 						// ID which isn't in the DB. return without a result so that a
 						// 404 is passed back to client


### PR DESCRIPTION
If an update request returns with this error:

```
{
    "meta": {
        "code": 400,
        "status": "fail",
        "message": "Failed to update quote object: Document too large: This BSON document is limited to 16777216 bytes.","method_name":"updateCustomObject"
    }
}
```

The error code interpreted on this side is caught here, and the error is suppressed.  This is bad behavior, since the update call acts as though the request was successful even though it was not.  This change allows the error to get through.